### PR TITLE
Get fluxsurface area

### DIFF
--- a/tests/NEO-2/python/test_get_fluxsurface_area.py
+++ b/tests/NEO-2/python/test_get_fluxsurface_area.py
@@ -1,27 +1,33 @@
 import pytest
 
+from libneo.eqdsk_base import approximate_fluxsurface_area_eqdsk
+
+
 @pytest.fixture
 def run_files():
     from libneo import read_eqdsk
+
     filename_eqdsk = "/proj/plasma/DATA/AUG/EQUILIRBRIUM/QCE_discharge_Neon_shot_39561/eqdsk_39461_5.38s"
     eqdsk = read_eqdsk(filename_eqdsk)
     neo2_output = "/temp/grassl_g/Neon_discharge_axisymmetric_gleiter/RUN_lag8/neon_discharge.out"
     yield eqdsk, neo2_output
 
+
 def test_get_fluxsurface_area_visual_check(run_files):
     from neo2_ql import get_fluxsurface_area
     from libneo import plot_fluxsurfaces, FluxConverter
     import matplotlib.pyplot as plt
+
     eqdsk, neo2_output = run_files
 
     area, stor = get_fluxsurface_area(neo2_output)
     converter = FluxConverter(eqdsk["qprof"])
     spol = converter.stor2spol(stor)
 
-    area_eqdsk, spol_eqdsk = get_fluxsurface_area_eqdsk(eqdsk)
+    area_eqdsk, spol_eqdsk = approximate_fluxsurface_area_eqdsk(eqdsk)
 
     plt.figure()
-    plt.plot(spol, area/1e4, "-r", label=r"fluxsurface area $S$")
+    plt.plot(spol, area / 1e4, "-r", label=r"fluxsurface area $S$")
     plt.plot(spol_eqdsk, area_eqdsk, "--b", label=r"approx area from EQDSK")
     plt.xlabel(r"$s_\mathrm{pol}$")
     plt.ylabel(r"$S \; \mathrm{[m^2]}$")
@@ -31,35 +37,5 @@ def test_get_fluxsurface_area_visual_check(run_files):
     plot_fluxsurfaces(eqdsk, "fluxsurfaces")
 
 
-def get_fluxsurface_area_eqdsk(eqdsk, n_surf: int=11):
-    import numpy as np
-    import matplotlib.pyplot as plt
-
-    normalized_flux = ((eqdsk["PsiVs"] - eqdsk["PsiaxisVs"]) / 
-                            (eqdsk["PsiedgeVs"] - eqdsk["PsiaxisVs"]))
-    spol = np.linspace(0, 1, n_surf)
-    Zmin = np.min(eqdsk["Lcfs"][:,1])
-    Zmax = np.max(eqdsk["Lcfs"][:,1])
-    I = (eqdsk["Z"] > Zmin) * (eqdsk["Z"] < Zmax)
-    fluxcontour = plt.contour(eqdsk["R"], eqdsk["Z"][I], normalized_flux[I], levels=spol)
-
-    def compute_distance(p1, p2):
-        return np.sqrt((p2[0] - p1[0])**2 + (p2[1] - p1[1])**2)
-
-    circumference = []
-    for flux_contour in fluxcontour.allsegs:
-        total_length = 0
-        points = np.array(flux_contour[0])
-        for idx in range(1, len(points)):
-            total_length += compute_distance(points[idx-1], points[idx])
-        circumference.append(total_length)
-    plt.close()
-    
-    area = 2*np.pi*eqdsk["R0"]*np.array(circumference)
-    area = area[:-1] # exclude separatrix
-    spol = spol[:-1]
-    return area, spol
-
-
-if __name__=="__main__":
+if __name__ == "__main__":
     pytest.main()

--- a/tests/NEO-2/python/test_get_fluxsurface_area.py
+++ b/tests/NEO-2/python/test_get_fluxsurface_area.py
@@ -1,5 +1,4 @@
 import pytest
-import h5py
 
 @pytest.fixture
 def run_files():
@@ -25,7 +24,7 @@ def test_get_fluxsurface_area_visual_check(run_files):
     plt.plot(spol, area/1e4, "-r", label=r"fluxsurface area $S$")
     plt.plot(spol_eqdsk, area_eqdsk, "--b", label=r"approx area from EQDSK")
     plt.xlabel(r"$s_\mathrm{pol}$")
-    plt.ylabel(r"$S \mathrm{ [m^2]}$")
+    plt.ylabel(r"$S \; \mathrm{[m^2]}$")
     plt.legend()
     plt.grid(True)
 
@@ -60,3 +59,7 @@ def get_fluxsurface_area_eqdsk(eqdsk, n_surf: int=11):
     area = area[:-1] # exclude separatrix
     spol = spol[:-1]
     return area, spol
+
+
+if __name__=="__main__":
+    pytest.main()

--- a/tests/NEO-2/python/test_get_fluxsurface_area.py
+++ b/tests/NEO-2/python/test_get_fluxsurface_area.py
@@ -1,6 +1,5 @@
 import pytest
 import h5py
-import numpy as np
 
 @pytest.fixture
 def run_files():
@@ -13,23 +12,51 @@ def run_files():
 def test_get_fluxsurface_area_visual_check(run_files):
     from neo2_ql import get_fluxsurface_area
     from libneo import plot_fluxsurfaces, FluxConverter
+    import matplotlib.pyplot as plt
     eqdsk, neo2_output = run_files
 
     area, stor = get_fluxsurface_area(neo2_output)
     converter = FluxConverter(eqdsk["qprof"])
     spol = converter.stor2spol(stor)
 
-    plot_area_over_spol(spol, area)
-    plot_fluxsurfaces(eqdsk, "fluxsurfaces")
+    area_eqdsk, spol_eqdsk = get_fluxsurface_area_eqdsk(eqdsk)
 
-def plot_area_over_spol(spol, area, show: bool=False):
-    import matplotlib.pyplot as plt
     plt.figure()
-    plt.plot(spol, area/1e4, "--r", label=r"fluxsurface area $S$")
+    plt.plot(spol, area/1e4, "-r", label=r"fluxsurface area $S$")
+    plt.plot(spol_eqdsk, area_eqdsk, "--b", label=r"approx area from EQDSK")
     plt.xlabel(r"$s_\mathrm{pol}$")
     plt.ylabel(r"$S \mathrm{ [m^2]}$")
     plt.legend()
     plt.grid(True)
-    if show:
-        plt.show()
 
+    plot_fluxsurfaces(eqdsk, "fluxsurfaces")
+
+
+def get_fluxsurface_area_eqdsk(eqdsk, n_surf: int=11):
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    normalized_flux = ((eqdsk["PsiVs"] - eqdsk["PsiaxisVs"]) / 
+                            (eqdsk["PsiedgeVs"] - eqdsk["PsiaxisVs"]))
+    spol = np.linspace(0, 1, n_surf)
+    Zmin = np.min(eqdsk["Lcfs"][:,1])
+    Zmax = np.max(eqdsk["Lcfs"][:,1])
+    I = (eqdsk["Z"] > Zmin) * (eqdsk["Z"] < Zmax)
+    fluxcontour = plt.contour(eqdsk["R"], eqdsk["Z"][I], normalized_flux[I], levels=spol)
+
+    def compute_distance(p1, p2):
+        return np.sqrt((p2[0] - p1[0])**2 + (p2[1] - p1[1])**2)
+
+    circumference = []
+    for flux_contour in fluxcontour.allsegs:
+        total_length = 0
+        points = np.array(flux_contour[0])
+        for idx in range(1, len(points)):
+            total_length += compute_distance(points[idx-1], points[idx])
+        circumference.append(total_length)
+    plt.close()
+    
+    area = 2*np.pi*eqdsk["R0"]*np.array(circumference)
+    area = area[:-1] # exclude separatrix
+    spol = spol[:-1]
+    return area, spol

--- a/tests/NEO-2/python/test_get_fluxsurface_area.py
+++ b/tests/NEO-2/python/test_get_fluxsurface_area.py
@@ -1,0 +1,35 @@
+import pytest
+import h5py
+import numpy as np
+
+@pytest.fixture
+def run_files():
+    from libneo import read_eqdsk
+    filename_eqdsk = "/proj/plasma/DATA/AUG/EQUILIRBRIUM/QCE_discharge_Neon_shot_39561/eqdsk_39461_5.38s"
+    eqdsk = read_eqdsk(filename_eqdsk)
+    neo2_output = "/temp/grassl_g/Neon_discharge_axisymmetric_gleiter/RUN_lag8/neon_discharge.out"
+    yield eqdsk, neo2_output
+
+def test_get_fluxsurface_area_visual_check(run_files):
+    from neo2_ql import get_fluxsurface_area
+    from libneo import plot_fluxsurfaces, FluxConverter
+    eqdsk, neo2_output = run_files
+
+    area, stor = get_fluxsurface_area(neo2_output)
+    converter = FluxConverter(eqdsk["qprof"])
+    spol = converter.stor2spol(stor)
+
+    plot_area_over_spol(spol, area)
+    plot_fluxsurfaces(eqdsk, "fluxsurfaces")
+
+def plot_area_over_spol(spol, area, show: bool=False):
+    import matplotlib.pyplot as plt
+    plt.figure()
+    plt.plot(spol, area/1e4, "--r", label=r"fluxsurface area $S$")
+    plt.xlabel(r"$s_\mathrm{pol}$")
+    plt.ylabel(r"$S \mathrm{ [m^2]}$")
+    plt.legend()
+    plt.grid(True)
+    if show:
+        plt.show()
+


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a72b8a65-2f45-47b0-b4cb-da430e670c9c)

Tests for the fluxsurface area calculation via `NEO-2` output. See also same name branches in `libneo` and `NEO-2`.