### PR TITLE
Correct debian setup script

### DIFF
--- a/scripts/setup/debian.sh
+++ b/scripts/setup/debian.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# src: https://stackoverflow.com/a/246128/16527499
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # Enable non-free packages
 sudo sed -i -e's/ main$/ main contrib non-free non-free-firmware/g' \
     /etc/apt/sources.list.d/debian.sources
@@ -8,9 +11,9 @@ sudo sed -i -e's/ main$/ main contrib non-free non-free-firmware/g' \
 
 sudo apt-get update -y && apt-get upgrade -y -q --no-install-recommends
 
-sudo $CODE/scripts/setup/debian/base.sh
-sudo $CODE/scripts/setup/debian/interactive.sh
-sudo $CODE/scripts/setup/debian/libs.sh
-sudo $CODE/scripts/setup/debian/octave.sh
-sudo $CODE/scripts/setup/debian/texlive.sh
-sudo $CODE/scripts/setup/debian/fonts.sh
+sudo $SCRIPT_DIR/debian/base.sh
+sudo $SCRIPT_DIR/debian/interactive.sh
+sudo $SCRIPT_DIR/debian/libs.sh
+sudo $SCRIPT_DIR/debian/octave.sh
+sudo $SCRIPT_DIR/debian/texlive.sh
+sudo $SCRIPT_DIR/debian/fonts.sh


### PR DESCRIPTION
Environment variable 'CODE' is not defined in this context. Get the absolute path of the calling script and define paths relative to it. Solution taken from https://stackoverflow.com/a/246128/16527499.