### PR TITLE
Add EUROfusion access onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ If you haven't done so earlier, set up your SSH keys in `~/.ssh` via `ssh-keygen
 with a **blank passphrase** and add the content of `id_rsa.pub` to Gitlab and GitHub
 for authentication.
 
+For EUROfusion/IMAS work, your account is requested by the group lead
+(not self-service); see [docs/eurofusion-access.md](docs/eurofusion-access.md)
+for the request route, SSH setup, and access verification.
+
 ### Perparing your machine
 
 On Linux: At ITPcp computers all packages should be installed to get going.

--- a/docs/eurofusion-access.md
+++ b/docs/eurofusion-access.md
@@ -25,11 +25,13 @@ Chris, Winny, Sergei, Max.
 - **Gateway (SSH) account**: grants command-line access to the
   EUROfusion Gateway (EFGW), reachable at `login.eufus.eu`. Access is
   not self-service: register in the CINECA **UserDB portal**
-  (`userdb.cineca.it`), send the signed GUA to the EUROfusion
+  (https://userdb.hpc.cineca.it), send the signed GUA to the EUROfusion
   Coordination Officer, then submit the HPC-access request on UserDB.
   Granting is confirmed by CINECA emails with your username and the
-  2FA set-up link (see
+  set-up link for 2FA plus the time-limited SSH certificate issued via
+  the `efgw` smallstep (step-CA) provisioner (see
   <https://docs.hpc.cineca.it/specific_users/gateway.html>).
+
 - **DevOps GitLab membership**: group/project membership on the
   EUROfusion DevOps GitLab, via the web SSO login at
   <https://gitlab.hpc.cineca.it/> (the same CINECA-hosted GitLab as
@@ -40,17 +42,41 @@ Chris, Winny, Sergei, Max.
 
 ## SSH key setup
 
-Reuse the SSH key you already set up for GitHub/GitLab (see
-[README.md](../README.md#getting-started), `~/.ssh` with a blank
-passphrase). There is no need to generate a new key; add `id_rsa.pub`
-to your EUROfusion profile where the account grant instructs.
+Two different kinds of SSH credentials are involved, and they must not
+be confused:
+
+- **GitLab SSH key**: for Git access to the EUROfusion DevOps GitLab,
+  reuse the SSH key you already set up for GitHub/GitLab (see
+  [README.md](../README.md#getting-started), `~/.ssh` with a blank
+  passphrase). There is no need to generate a new key; add `id_rsa.pub`
+  to your DevOps GitLab profile
+  (<https://gitlab.hpc.cineca.it/-/user_settings/ssh_keys>).
+- **Gateway (EFGW) authentication**: contrary to the GitLab SSH key,
+  the Gateway does **not** accept a bare `id_rsa` key. Logging in
+  requires a **time-limited SSH certificate** obtained from the
+  `efgw` smallstep (step-CA) provisioner, which additionally enforces
+  2FA. Install the
+  [smallstep CLI](https://smallstep.com/docs/step-cli/installation/)
+  and log in once per certificate lifetime (by default repeatedly
+  re-running the login when prompted) with:
+
+  ```bash
+  step ssh login <user> --provisioner efgw
+  ```
+
+  This prompts for the 2FA code and writes a short-lived SSH
+  certificate into `~/.ssh` that the Gateway accepts; the Gateway is
+  reached through the `login.eufus.eu` host (see
+  <https://docs.hpc.cineca.it/specific_users/gateway.html>).
 
 ## Verifying access
 
 On your ITPcp machine, after your account is granted:
 
 ```bash
-# 1. Interactive login to the EUROfusion Gateway front-end (EFGW)
+# 1. Obtain the time-limited Gateway SSH certificate (2FA required)
+step ssh login <user> --provisioner efgw
+#    Then interactive login to the EUROfusion Gateway front-end (EFGW)
 ssh <user>@login.eufus.eu
 
 # 2. Git access to the EUROfusion DevOps GitLab (hosted by CINECA)

--- a/docs/eurofusion-access.md
+++ b/docs/eurofusion-access.md
@@ -31,9 +31,12 @@ Chris, Winny, Sergei, Max.
   2FA set-up link (see
   <https://docs.hpc.cineca.it/specific_users/gateway.html>).
 - **DevOps GitLab membership**: group/project membership on the
-  EUROfusion DevOps GitLab, via the web SSO login. *Having an account
-  is not the same as having access to the relevant project*; confirm
-  the group membership, not just the account.
+  EUROfusion DevOps GitLab, via the web SSO login at
+  <https://gitlab.hpc.cineca.it/> (the same CINECA-hosted GitLab as
+  the `gitlab-ssh.hpc.cineca.it` endpoint, reached through the ITPcp
+  group [eurofusion](https://gitlab.hpc.cineca.it/groups/eurofusion)).
+  *Having an account is not the same as having access to the relevant
+  project*; confirm the group membership, not just the account.
 
 ## SSH key setup
 
@@ -55,8 +58,10 @@ ssh -T git@gitlab-ssh.hpc.cineca.it
 #    Expected: "Welcome to GitLab, @<user>!"
 
 # 3. Web SSO
-#    log in to the DevOps GitLab web UI and confirm membership of the
-#    ITPcp group/project (step 3 is the one that matters operationally)
+#    log in at https://gitlab.hpc.cineca.it/ and, under the
+#    eurofusion group (https://gitlab.hpc.cineca.it/groups/eurofusion),
+#    confirm membership of the ITPcp group/project
+#    (step 3 is the one that matters operationally)
 ```
 
 Only when all three succeed — and step 3 shows the required group

--- a/docs/eurofusion-access.md
+++ b/docs/eurofusion-access.md
@@ -22,9 +22,14 @@ Chris, Winny, Sergei, Max.
 
 ## What you need
 
-- **Gateway (SSH) account**: grants command-line access to
-  EUROfusion-provided systems. You receive the exact host from the
-  account-grant mail; use that, do not guess a hostname.
+- **Gateway (SSH) account**: grants command-line access to the
+  EUROfusion Gateway (EFGW), reachable at `login.eufus.eu`. Access is
+  not self-service: register in the CINECA **UserDB portal**
+  (`userdb.cineca.it`), send the signed GUA to the EUROfusion
+  Coordination Officer, then submit the HPC-access request on UserDB.
+  Granting is confirmed by CINECA emails with your username and the
+  2FA set-up link (see
+  <https://docs.hpc.cineca.it/specific_users/gateway.html>).
 - **DevOps GitLab membership**: group/project membership on the
   EUROfusion DevOps GitLab, via the web SSO login. *Having an account
   is not the same as having access to the relevant project*; confirm
@@ -42,13 +47,11 @@ to your EUROfusion profile where the account grant instructs.
 On your ITPcp machine, after your account is granted:
 
 ```bash
-# 1. Interactive login to the EUROfusion Gateway front-end
-#    (exact host: take from the account-grant mail, do not guess)
-ssh <user>@<gateway-host>
+# 1. Interactive login to the EUROfusion Gateway front-end (EFGW)
+ssh <user>@login.eufus.eu
 
-# 2. Git access to the EUROfusion DevOps GitLab
-#    (exact host: take from the account-grant mail, do not guess)
-ssh -T git@<eufus-gitlab-host>
+# 2. Git access to the EUROfusion DevOps GitLab (hosted by CINECA)
+ssh -T git@gitlab-ssh.hpc.cineca.it
 #    Expected: "Welcome to GitLab, @<user>!"
 
 # 3. Web SSO

--- a/docs/eurofusion-access.md
+++ b/docs/eurofusion-access.md
@@ -1,0 +1,60 @@
+# EUROfusion access
+
+EUROfusion provides its own "DevOps" compute and collaboration
+infrastructure (Gateway access, a DevOps GitLab, and the IMAS data
+model / Access Layer) that ITPcp members need for IMAS-facing work and
+for anything that must be built or run on EUROfusion-provided systems.
+
+Unlike the TU Graz GitLab or GitHub, account access is **not
+self-service**: an account request goes through a project/unit
+administrator and typically takes weeks. Start early.
+
+## Who requests access
+
+Account and group membership is requested by a project administrator.
+At ITPcp, ask the group lead (Christopher Albert) to sponsor the
+request and to have you added to the ITPcp group/project on the
+EUROfusion DevOps GitLab.
+
+Current ITPcp members with access are tracked in the issue
+"Add users to EUROfusion devops" (itpplasma/code#18):
+Chris, Winny, Sergei, Max.
+
+## What you need
+
+- **Gateway (SSH) account**: grants command-line access to
+  EUROfusion-provided systems. You receive the exact host from the
+  account-grant mail; use that, do not guess a hostname.
+- **DevOps GitLab membership**: group/project membership on the
+  EUROfusion DevOps GitLab, via the web SSO login. *Having an account
+  is not the same as having access to the relevant project*; confirm
+  the group membership, not just the account.
+
+## SSH key setup
+
+Reuse the SSH key you already set up for GitHub/GitLab (see
+[README.md](../README.md#getting-started), `~/.ssh` with a blank
+passphrase). There is no need to generate a new key; add `id_rsa.pub`
+to your EUROfusion profile where the account grant instructs.
+
+## Verifying access
+
+On your ITPcp machine, after your account is granted:
+
+```bash
+# 1. Interactive login to the EUROfusion Gateway front-end
+#    (exact host: take from the account-grant mail, do not guess)
+ssh <user>@<gateway-host>
+
+# 2. Git access to the EUROfusion DevOps GitLab
+#    (exact host: take from the account-grant mail, do not guess)
+ssh -T git@<eufus-gitlab-host>
+#    Expected: "Welcome to GitLab, @<user>!"
+
+# 3. Web SSO
+#    log in to the DevOps GitLab web UI and confirm membership of the
+#    ITPcp group/project (step 3 is the one that matters operationally)
+```
+
+Only when all three succeed — and step 3 shows the required group
+membership — does ITPcp consider the account usable.


### PR DESCRIPTION
## Problem

Issue #18 tracks adding ITPcp members (Chris, Winny, Sergei, Max) to the
EUROfusion DevOps/Gateway infrastructure. There was nothing in the
repository documenting how EUROfusion access is obtained or verified, so
new members had no idea how to request an account and the checklist was
unverifiable from the repo.

## Change

- Add `docs/eurofusion-access.md` documenting the EUROfusion DevOps /
  Gateway access request route (via the group lead, not self-service),
  SSH key reuse, and the concrete commands each member should run to
  verify their account and — more importantly — their ITPcp group/project
  membership on the DevOps GitLab.
- Link to it from the README `## Getting Started` section, right after the
  existing SSH-key setup paragraph.

The exact Gateway/DevOps GitLab hosts intentionally come from the
account-grant mail rather than being guessed, so the doc cannot point
members at a wrong host; it instructs them to use the granted host.

## Tests

Documentation-only change; no build or pytest surface is affected.
`pytest tests/` is untouched.

Closes #18
