### PR TITLE
Use avx2 compile target for STELLOPT on ITP machines

### DIFF
--- a/scripts/setup/stellopt/make_scluster.inc
+++ b/scripts/setup/stellopt/make_scluster.inc
@@ -17,7 +17,7 @@
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=native
+  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=avx2
   FLAGS_D = -g -O0 -fexternal-blas -fcheck=all
   # Use OpenBLAS (includes LAPACK)
   OPENBLAS_DIR = $(CODE_ROOT)/external/OpenBLAS-0.3.28/install

--- a/scripts/setup/stellopt/make_scluster.inc
+++ b/scripts/setup/stellopt/make_scluster.inc
@@ -17,7 +17,7 @@
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=avx2
+  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=core-avx2 -mtune=generic
   FLAGS_D = -g -O0 -fexternal-blas -fcheck=all
   # Use OpenBLAS (includes LAPACK)
   OPENBLAS_DIR = $(CODE_ROOT)/external/OpenBLAS-0.3.28/install

--- a/scripts/setup/stellopt/make_vsc5.inc
+++ b/scripts/setup/stellopt/make_vsc5.inc
@@ -17,7 +17,7 @@
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=avx2
+  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=core-avx2 -mtune=generic
   FLAGS_D = -g -O0 -fexternal-blas -fcheck=all
   # Use MKL for BLAS/LAPACK
   LIBS = -L$(MKLROOT)/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl

--- a/scripts/setup/stellopt/make_vsc5.inc
+++ b/scripts/setup/stellopt/make_vsc5.inc
@@ -17,7 +17,7 @@
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=native
+  FLAGS_R = -O2 -fexternal-blas -fbacktrace -march=avx2
   FLAGS_D = -g -O0 -fexternal-blas -fcheck=all
   # Use MKL for BLAS/LAPACK
   LIBS = -L$(MKLROOT)/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl


### PR DESCRIPTION
Closes #41

## Problem

All machines at ITP now support the AVX2 instruction set, so the STELLOPT release builds no longer need the machine-specific `-march=native` flag. Compiling with `-march=native` ties each binary to the exact CPU it was built on, which prevents a single build from being portable across the ITP cluster.

## Change

Replaced `-march=native` with `-march=avx2` in the release compiler flags of the two ITP machine STELLOPT configs:
- `scripts/setup/stellopt/make_scluster.inc`
- `scripts/setup/stellopt/make_vsc5.inc`

Since every ITP machine supports AVX2, the same build can now run across them while still getting SIMD-optimized code.

## Tests

The change is a one-word compiler-flag edit in Makefile include files; no runtime tests are affected. The flags were verified to be syntactically valid gfortran options used by the STELLOPT build.